### PR TITLE
feat: expose updates page inside main page

### DIFF
--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -1,8 +1,9 @@
 ---
 title: "Redbrick Wiki"
 description: "Welcome to the Redbrick Wiki. Learn about different content types in Redbrick Engine."
+hideTitle: true
 ---
-import { Callout } from "nextra/components";
+import Updates from './faq/updates.mdx';
 
 # Hi, we are Redbrick
 
@@ -11,4 +12,6 @@ For those who visit Redbrick for the first time, we have organized descriptions 
 
 Let's make everything you imagine with Redbrick.
 
-<Callout type="info">Checkout recent updates [here](/en/faq/updates)</Callout>
+<div style={{ marginTop: '100px' }}>
+  <Updates />
+</div>

--- a/pages/kr/index.mdx
+++ b/pages/kr/index.mdx
@@ -2,7 +2,7 @@
 title: "레드브릭 위키"
 description: "레드브릭 위키에 오신 것을 환영합니다. 레드브릭 엔진의 다양한 콘텐츠 유형에 대해 알아보세요."
 ---
-import { Callout } from "nextra/components";
+import Updates from './faq/updates.mdx';
 
 # 안녕하세요, 레드브릭입니다
 
@@ -11,6 +11,6 @@ import { Callout } from "nextra/components";
 
 레드브릭과 함께 상상하는 모든 것을 만들어봅시다.
 
-<Callout type="info">
-  [이곳](../kr/faq/updates)에서 최근 업데이트 내용을 확인해보세요
-</Callout>
+<div style={{ marginTop: '100px' }}>
+  <Updates />
+</div>


### PR DESCRIPTION
I honestly think exposing Updates page inside main page have following benefits

- better accessibility for newer critical updates(who even checks faq/updates)
- better SEO, more visits higher SEO exposure for new contents. As newly added contents will likely have less visits and bad SEO
- we need to cover with something our empty landing page


## Demo


https://github.com/user-attachments/assets/a0440a03-b6e0-431b-9a5b-118c10afc72e

